### PR TITLE
Fix /f claim square

### DIFF
--- a/src/DaPigGuy/PiggyFactions/commands/subcommands/claims/claim/ClaimMultipleSubCommand.php
+++ b/src/DaPigGuy/PiggyFactions/commands/subcommands/claims/claim/ClaimMultipleSubCommand.php
@@ -18,7 +18,7 @@ abstract class ClaimMultipleSubCommand extends FactionSubCommand
 
     public function onNormalRun(Player $sender, ?Faction $faction, FactionsPlayer $member, string $aliasUsed, array $args): void
     {
-        if (in_array($sender->getWorld()->getFolderName(), $this->plugin->getConfig()->getNested("factions.claims.whitelisted-worlds"))) {
+        if (!in_array($sender->getWorld()->getFolderName(), $this->plugin->getConfig()->getNested("factions.claims.whitelisted-worlds"))) {
             $member->sendMessage("commands.claim.whitelisted-world");
             return;
         }


### PR DESCRIPTION
Added a missing not condition (has been missing since the check went from blacklisted-worlds to whitelistes worlds)